### PR TITLE
SS-1988 get minimium order amount

### DIFF
--- a/Api/GetManagementInterface.php
+++ b/Api/GetManagementInterface.php
@@ -24,4 +24,10 @@ interface GetManagementInterface {
      * @return mixed
      */
      public function getBestSellingProducts($period);
+
+     /**
+     * Get Minimium Order Amount
+     * @return mixed
+     */
+     public function getMinimiumOrderAmount();
 }

--- a/Model/GetManagement.php
+++ b/Model/GetManagement.php
@@ -23,10 +23,12 @@ class GetManagement {
 
     public function __construct(
         \Magento\Framework\Webapi\Exception $exception,
+        \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig,
         \Magento\Catalog\Api\ProductRepositoryInterface $productRepository,
         \Magento\Sales\Model\ResourceModel\Report\Bestsellers\CollectionFactory $collectionFactory
     ) {
         $this->exception = $exception;
+        $this->scopeConfig = $scopeConfig;
         $this->productRepository = $productRepository;
         $this->collectionFactory = $collectionFactory;
     }
@@ -69,6 +71,15 @@ class GetManagement {
             }
 
             return $this->response;
+        } catch(\Exception $e) {
+            throw new $this->exception(__($e->getMessage()),0,$this->exception::HTTP_BAD_REQUEST);
+        }
+    }
+
+    public function getMinimiumOrderAmount()
+    {
+        try {
+            return $this->scopeConfig->getValue('sales/minimum_order/amount', \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         } catch(\Exception $e) {
             throw new $this->exception(__($e->getMessage()),0,$this->exception::HTTP_BAD_REQUEST);
         }

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -31,4 +31,10 @@
 	                <resource ref="self"/>
 	        </resources>
 	</route>
+	<route method="GET" url="/V1/sales/minimum-order-amount">
+	        <service class="Grability\Mobu\Api\GetManagementInterface" method="getMinimiumOrderAmount"/>
+	        <resources>
+	                <resource ref="self"/>
+	        </resources>
+	</route>
 </routes>


### PR DESCRIPTION
**Link al ticket**: https://grability.atlassian.net/browse/SS-1988

**Bitácora de análisis**

Se requiere extender el API de magento para que exponga la información de pedido mínimo que será consumida por the wall

**Bitácora de desarrollo**

Se crea el servicio sales/minimum-order-amount para consultar el pedido mínimo configurado en Magento